### PR TITLE
GetPickupParents() function implementation

### DIFF
--- a/ABaseController/ABaseController.cpp
+++ b/ABaseController/ABaseController.cpp
@@ -166,7 +166,7 @@ void ABaseController::OnOverlapBegin(UPrimitiveComponent* OverlappedComp,
         APickup* pPickupActor = Cast<APickup>(OtherActor);
         if (pPickupActor) {
             // outline mesh if not held by anything
-            if (pPickupActor->m_aParentActors.Num() == 0)
+            if (pPickupActor->GetPickupParents().Num() == 0)
                 pPickupActor->m_pPickupMeshComponent->SetRenderCustomDepth(true);
         }
     }

--- a/APickup/APickup.cpp
+++ b/APickup/APickup.cpp
@@ -126,6 +126,8 @@ APickup::APickup() {
     m_pPickupMeshComponent->SetSimulatePhysics(true);
 }
 
+TArray<AActor*> APickup::GetPickupParents() { return m_aParentActors; }
+
 void APickup::Pickup(ABaseController* controller) {
     if (m_pPickupMeshComponent->GetStaticMesh()) {
         m_pPickupMeshComponent->SetSimulatePhysics(false);

--- a/APickup/APickup.h
+++ b/APickup/APickup.h
@@ -15,7 +15,10 @@ class VRBASE_API APickup : public ABaseEntity {
 public:
     APickup();
 
+private:
     TArray<AActor*>           m_aParentActors;
+
+public:
     UStaticMeshComponent*     m_pPickupMeshComponent;
     UProceduralMeshComponent* m_pProcMeshComponent;
 
@@ -63,6 +66,8 @@ public:
         Super::PostEditChangeProperty(PropertyChangedEvent);
     }
 #endif
+    UFUNCTION(BlueprintCallable)
+    TArray<AActor*> GetPickupParents();
 
     virtual void Pickup(ABaseController*);
     virtual void Drop(ABaseController*);


### PR DESCRIPTION
The array `m_aParentActors` of APickup is public and unnecessarily exposed. There is no circumstance that the parent actors of a pickup would be altered by a separate pickup or entity.

This branch changed the `TArray<AActor*> m_aParentActors` of APickup, into a private member variable and added the function `GetPickupParents()` as a way for that variable to be accessed by ABaseController, which uses it in the function `OnOverlapBegin` to see if the pickup is being held by other things..

Further Development:
Changing how `OnOverlapBegin` works so that it does not require the use of `m_aParentActors` of APickup. It would allow the removal of `GetPickupParents()` as a function and make `m_aParentActors` secure.