### PR TITLE
Bugfix/unreal tick function

### DIFF
--- a/ABaseEntity/ABaseEntity.h
+++ b/ABaseEntity/ABaseEntity.h
@@ -52,7 +52,7 @@ public:
 
     // unrecommended to override AActor functions
     virtual void BeginPlay() override;
-    virtual void Tick(float deltaTime) override {}
+    virtual void Tick(float deltaTime) override { Super::Tick(deltaTime); }
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override {}
     virtual void PostDuplicate(EDuplicateMode::Type mode) override {
         Super::PostDuplicate(mode);


### PR DESCRIPTION
When in the editor, the UE `Tick()` function is not called each frame as it should. I have found out that it is now required to call the parent `Tick()` function for the UE tick to work properly.

Changes:
- Added "Super::Tick(deltaTime);" to ABaseEntity `Tick()` function