### PR TITLE
Add Code Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # VRBase Library 2.0.0
-VRBase is a C++ Unreal Engine library designed to simplify virtual reality development in Unreal. It includes a variety of different classes, each of which perform specific functionality designed to improve overall ease of development.
+VRBase is a simple C++ Unreal Engine 4 library designed to simplify virtual reality development in the Unreal Editor. It includes a variety of different classes, each of which perform specific functionality designed to improve overall ease of development.
 
-VRBase implements all basic virtual reality actors (such as the player pawn) C++. You will not need to program the camera or controllers, allowing greater flexibility in game development.
+VRBase implements all essential virtual reality classes in C++. This mitigates the need to program a camera or controllers, allowing greater flexibility in game development.
 
 ## Table of Contents
 1. [Installation](#install)
-2. [Linting](#linting)
-3. [Example VRBase Projects](#projects)
+2. [Code Formatting](#codeFormatting)
+3. [VRBase Projects](#projects)
 4. [Documentation](#doc)
 
 ## Installation <a name="install"></a>
-VRBase is only a library and therefore can only be added to an existing Unreal project.
+VRBase must be added to an _existing_ Unreal project.
 
-1. Clone VRBase into an Unreal project under the directory `Source/PROJECTNAME/VRBase`.
+1. Clone VRBase into an existing Unreal project under the directory `Source/PROJECTNAME/VRBase`.
 2. Right-click the Unreal `uproject` file in the main root directory and select _Generate Visual Studio Project Files_ to regenerate a clean Visual Studio `sln` file.
 3. Update the `PROJECTNAME.Build.cs` file to include VRBase. This file is located in the `Source/PROJECTNAME/` directory. The snippet below can be copied and pasted into the file. **Be sure to change the project name**:
 ```cs
@@ -34,22 +34,30 @@ public class YOURPROJECTNAME : ModuleRules {
     }
 }
 ```
-4. After opening the Unreal project in the editor, VRBase **requires** an instance of [AGameRules](Doc/AGameRules.md) to be included in the level UMap for VRBase to function properly. VRBase classes may not work otherwise.
+4. After opening the Unreal project in the editor, VRBase **requires** an instance of [AGameRules](Doc/AGameRules.md) to be included in the level UMap for VRBase to function properly. VRBase classes will not function properly otherwise.
 
-## Linting <a name="linting"></a>
-Code linting is the process of running a program to check and format source code files 
-according to a certain project or language specification. Without linting, each developer
-adds their own code style to the codebase, causing inconsistent formatting and making source
-code harder to read.
+## Code Formatting <a name="codeFormatting"></a>
+Code formatting, also known as linting, is the process of running a program to check and format source code files  according to a certain project or language specification. Without linting, each developer adds their own code style to the codebase, causing inconsistent formatting and making source code harder to read. Linting fixes these issues by formatting code for developers, allowing developers to focus more on the content of the code rather than indentation and spacing.
 
-This project uses the default 
-[`clang-format`](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) 
-linter, available as an extension for VS Code. You will also need to download the `clang`
-libraries found on the [LLVM download page](https://releases.llvm.org/download.html),
-using the LLVM 10.0.0 Windows 64-bit pre-built binary. Be sure to add LLVM to the
-system path for all users when prompted.
+In VRBase, we use `clang-format` to maintain our codebase. To add this to your editor/IDE:
 
-`Format On Save` should be enabled in VS Code settings in order for this to work:
+**Visual Studio:**
+
+Typing `ctrl-k ctrl-d` will automatically format the focused document.
+
+However, Visual Studio does not offer any method of auto-formatting code on save, so
+each edited file will need to be formatted manually.
+
+**Visual Studio Code:**
+
+Download the `clang` libraries found on the [LLVM download page](https://releases.llvm.org/download.html),
+using the [LLVM 11.0.0 Windows 64-bit pre-built binary](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe). 
+**Be sure to add LLVM to the system path for all users if prompted.** Once installed, you will need to restart your computer for your system path to be updated.
+
+Next, install the [`clang-format`](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) 
+extension for VS Code. Once installed, you can enable `Format On Save` in VS Code settings to automatically format your code on save.
+
+Alternatively, you can edit the json settings as follows:
 ```json
 "[cpp]": {
     "editor.defaultFormatter": "xaver.clang-format",
@@ -57,10 +65,11 @@ system path for all users when prompted.
 },
 ```
 
-## Example VRBase Projects <a name="projects"></a>
-Below is a list of projects in which VRBase has been used:
+## VRBase Projects <a name="projects"></a>
+Below is a cumulative list of projects in which VRBase has been used:
 
 - [Archery](https://github.com/bossley9/Archery)
+- [Crime Solver](https://github.com/MMC-Scholars/CrimeSolver)
 - [The Great Balloon Race](https://github.com/MMC-Scholars/TheGreatBalloonRace)
 - [Office Recreation](https://github.com/MMC-Scholars/OfficeRecreation)
 


### PR DESCRIPTION
**The Problem:**
We need consistent code formatting set up in VRBase to prevent developer code styles from conflicting. Keeping a consistent code format improves code readability and lets developers focus on the content of the code instead of the number of tabs a statment should have.

Ideally, we would use an auto-formatter, which would format code on each save.

**The Solution:**
I updated the readme to include steps on how to set up code formatting. From now on, anyone contributing to VRBase will need to format code in order to merge their feature branches.

**Additional Changes:**
I updated the readme's wording and added Crime Solver to the list of projects.