### PR TITLE
Clean Gamerules (2)

### DIFF
--- a/ABaseEntity/ABaseEntity.cpp
+++ b/ABaseEntity/ABaseEntity.cpp
@@ -12,7 +12,8 @@ ABaseEntity::ABaseEntity() : IBaseEntity() {
 
 void ABaseEntity::BeginPlay() {
     g_pGlobals->checkReset();
-    AActor::BeginPlay();
+    Super::BeginPlay();
+    IBaseEntity::BeginPlay();
     ReportReady();
 
     // if the game has already started, call initializations

--- a/ABaseEntity/ABaseEntity.h
+++ b/ABaseEntity/ABaseEntity.h
@@ -51,9 +51,13 @@ public:
     virtual void OnUsed(ABaseEntity* pActivator) {}
 
     // unrecommended to override AActor functions
-    virtual void BeginPlay() override;
+    void BeginPlay() override;
+    void EndPlay(const EEndPlayReason::Type EndPlayReason) override {
+        Super::EndPlay(EndPlayReason);
+        IBaseEntity::EndPlay(EndPlayReason);
+    }
+
     virtual void Tick(float deltaTime) override { Super::Tick(deltaTime); }
-    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override {}
     virtual void PostDuplicate(EDuplicateMode::Type mode) override {
         Super::PostDuplicate(mode);
         IBaseEntity::PostDuplicate(mode);

--- a/ABasePawn/ABasePawn.h
+++ b/ABasePawn/ABasePawn.h
@@ -18,9 +18,10 @@ class VRBASE_API ABasePawn : public APawn, public IBaseEntity {
 public:
     ABasePawn();
 
-    virtual void BeginPlay() override {
+    void BeginPlay() override {
         g_pGlobals->checkReset();
-        APawn::BeginPlay();
+        Super::BeginPlay();
+        IBaseEntity::BeginPlay();
         ReportReady();
 
         if (g_pGameBase && g_pGameBase->GameReady()) {
@@ -28,11 +29,18 @@ public:
             PostInit();
         }
     }
+    void EndPlay(const EEndPlayReason::Type EndPlayReason) override {
+        Super::EndPlay(EndPlayReason);
+        IBaseEntity::EndPlay(EndPlayReason);
+    }
+
     virtual void Tick(float deltaTime) override {}
+
     virtual void PostDuplicate(EDuplicateMode::Type mode) override {
         Super::PostDuplicate(mode);
         IBaseEntity::PostDuplicate(mode);
     }
+
     virtual void
     SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 

--- a/AGameBase/AGameBase.cpp
+++ b/AGameBase/AGameBase.cpp
@@ -45,8 +45,7 @@ void AGameBase::Tick(float deltaTime) {
     g_pGlobals->update();
 }
 
-UWorld* g_pWorld = NULL;
-void    AGameBase::BeginPlay() {
+void AGameBase::BeginPlay() {
     Super::BeginPlay();
     ADebug::Assert((bool)(s_iEntityCount = g_entList.Num()),
                    "\nIBaseEntity::s_iEntityCount = g_entList.Num()");
@@ -55,8 +54,6 @@ void    AGameBase::BeginPlay() {
     m_bHasInitializedAllEntities = false;
 
     m_tNextRoundRestart = -FLT_MAX;
-
-    g_pWorld = GetWorld();
 }
 
 void AGameBase::EndPlay(const EEndPlayReason::Type EndPlayReason) {

--- a/AGameBase/AGameBase.cpp
+++ b/AGameBase/AGameBase.cpp
@@ -47,8 +47,9 @@ void AGameBase::Tick(float deltaTime) {
 
 void AGameBase::BeginPlay() {
     Super::BeginPlay();
-    ADebug::Assert((bool)(s_iEntityCount = g_entList.Num()),
-                   "\nIBaseEntity::s_iEntityCount = g_entList.Num()");
+
+    ADebug::Assert(s_iEntityCount == g_entList.Num(),
+                   "\nIBaseEntity::s_iEntityCount == g_entList.Num()");
 
     m_bHasRestartedRound         = false;
     m_bHasInitializedAllEntities = false;
@@ -57,6 +58,7 @@ void AGameBase::BeginPlay() {
 }
 
 void AGameBase::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+    Super::EndPlay(EndPlayReason);
     m_bHasInitializedAllEntities = false;
     g_pGlobals->markReset();
 }

--- a/IBaseEntity/IBaseEntity.cpp
+++ b/IBaseEntity/IBaseEntity.cpp
@@ -4,6 +4,9 @@
 IBaseEntity*         g_ppEntityList[MAX_ENTITY_COUNT] = {NULL};
 TArray<IBaseEntity*> g_entList;
 
+// required to be redeclared in source file (cpp) for linker to detect it
+TArray<IBaseEntity*> IBaseEntity::s_aBaseEntities;
+
 // a global index which keeps track of where we last inserted an entity into the
 // list
 static eindex g_iEntityCounter = 0;

--- a/IBaseEntity/IBaseEntity.h
+++ b/IBaseEntity/IBaseEntity.h
@@ -77,10 +77,19 @@ public:
     inline eindex EntIndex() const { return m_iEntIndex; }
     EHANDLE       GetEHandle() const { return EHANDLE(this); }
 
+    // A collection of references to all BaseEntities present in the world
+    // at any given moment
+    static TArray<IBaseEntity*> s_aBaseEntities;
+
 private:
     eindex m_iEntIndex;
 
 protected:
+    void BeginPlay() { IBaseEntity::s_aBaseEntities.Add(this); }
+    void EndPlay(const EEndPlayReason::Type EndPlayReason) {
+        IBaseEntity::s_aBaseEntities.Remove(this);
+    }
+
     void        PostDuplicate(EDuplicateMode::Type mode);
     static void AddEntityToLists(IBaseEntity * pEnt);
     static int  s_iReadyEntityCount;

--- a/System/Globals.h
+++ b/System/Globals.h
@@ -25,7 +25,6 @@ private:
 };
 
 extern CGlobalVars* g_pGlobals;
-extern UWorld*      g_pWorld;
 
 inline bool IsCookedBuild() { return !WITH_EDITOR; }
 


### PR DESCRIPTION
## Problem
VRBase has grown into a large behemoth of code with highly extensible members; however, for the scopes of most projects, many of these features are largely unneeded and unused. We need a simpler VRBase set of classes which are easy for new VRBase contributers to understand and provide core functionality that is universal across the majority of VR projects.

In order to make VRBase a plugin, we need to remove all global variables or macros, since they will not translate over to individual project classes due to scope.

In particular, we will not be able to use `Globals` in the future and we need to phase out the code systematically. I believe the best way to go about this is by moving everything to `GameRules` (now renamed to `GameBase` as static members. In addition to controlling game logic flow, `GameBase` will also contain all generic project utilities and "global" variables that may be needed throughout a project.

This PR is one of many that will focus on cleaning existing `GameRules` code and moving global items into `GameRules`.

## Solution
I decided to use a static `TArray` variable to record and count the number of `BaseEntities`. The list is incremented and decremented on each `BaseEntity`'s `BeginPlay` and `EndPlay` methods respectively. I actually think this is a slightly more elegant method of entity counting than the original implementation because

1. [We don't have to worry about duplication](https://docs.unrealengine.com/en-US/Programming/UnrealArchitecture/Actors/ActorLifecycle/index.html), i.e. we don't need to worry about duplicated actors OR things not getting called properly in cooked games.
2. We don't need a separate class (i.e. `CGlobalVars`) to manage resetting the entity counts when the game begins and ends.
3. `BeginPlay` and `EndPlay` are both discouraged from being overridden in all derived IBaseEntity classes, so why not use the empty function implementations?
4. With this implementation, VRBase grows more in similarity to VRBase-Unity. This is a benefit because it makes it much easier for devs to switch between Unreal and Unity.
5. `BeginPlay` and `EndPlay` methods are so much easier to understand than `DestroyEntity`, `RemoveSelfFromLists`, `AddSelfToLists`, `PostDuplicate`, ... if you disagree with me then you're blatantly wrong.

I still have yet to remove the original entity counting system since I want to make sure I do not break anything in our existing projects (i.e. CrimeSolver).

### tl;dr - I reinvented a better entity counting system but I haven't deleted any of the old counting system code yet bc I don't want to break CrimeSolver until I know it's safe to remove it