### PR TITLE
Clean Gamerules (3)

### DIFF
--- a/ABaseEntity/ABaseEntity.cpp
+++ b/ABaseEntity/ABaseEntity.cpp
@@ -16,14 +16,6 @@ void ABaseEntity::BeginPlay() {
     IBaseEntity::BeginPlay();
     ReportReady();
 
-    // if the game has already started, call initializations
-    /*
-    if (g_pGameBase && g_pGameBase->GameReady()) {
-        PreInit();
-        PostInit();
-    }
-    */
-
     // initial world transform (rotation, location, scale)
     m_tInitialTransform =
         FTransform(GetActorRotation(), GetActorLocation(), GetActorScale());

--- a/ABaseEntity/ABaseEntity.cpp
+++ b/ABaseEntity/ABaseEntity.cpp
@@ -17,10 +17,12 @@ void ABaseEntity::BeginPlay() {
     ReportReady();
 
     // if the game has already started, call initializations
+    /*
     if (g_pGameBase && g_pGameBase->GameReady()) {
         PreInit();
         PostInit();
     }
+    */
 
     // initial world transform (rotation, location, scale)
     m_tInitialTransform =

--- a/ABaseEntity/ABaseEntity.h
+++ b/ABaseEntity/ABaseEntity.h
@@ -48,6 +48,20 @@ public:
 
     ABaseEntity();
 
+    /// Is called exactly once as soon as the BaseEntity has spawned in the world
+    UFUNCTION(BlueprintNativeEvent, DisplayName = "PreInit")
+    void         PreInit();
+    virtual void PreInit_Implementation() {
+        IBaseEntity::PreInit();
+    }; // provided solely for Blueprint implementations
+
+    /// Is called exactly once immediately following PreInit()
+    UFUNCTION(BlueprintNativeEvent, DisplayName = "PostInit")
+    void         PostInit();
+    virtual void PostInit_Implementation() {
+        IBaseEntity::PostInit();
+    }; // provided solely for Blueprint implementations
+
     virtual void OnUsed(ABaseEntity* pActivator) {}
 
     // unrecommended to override AActor functions

--- a/ABaseEntity/ABaseEntity.h
+++ b/ABaseEntity/ABaseEntity.h
@@ -72,10 +72,6 @@ public:
     }
 
     virtual void Tick(float deltaTime) override { Super::Tick(deltaTime); }
-    virtual void PostDuplicate(EDuplicateMode::Type mode) override {
-        Super::PostDuplicate(mode);
-        IBaseEntity::PostDuplicate(mode);
-    }
 
     // "Use" controller input
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input)

--- a/ABasePawn/ABasePawn.h
+++ b/ABasePawn/ABasePawn.h
@@ -23,12 +23,6 @@ public:
         Super::BeginPlay();
         IBaseEntity::BeginPlay();
         ReportReady();
-        /*
-        if (g_pGameBase && g_pGameBase->GameReady()) {
-            PreInit();
-            PostInit();
-        }
-        */
     }
     void EndPlay(const EEndPlayReason::Type EndPlayReason) override {
         Super::EndPlay(EndPlayReason);
@@ -36,11 +30,6 @@ public:
     }
 
     virtual void Tick(float deltaTime) override {}
-
-    virtual void PostDuplicate(EDuplicateMode::Type mode) override {
-        Super::PostDuplicate(mode);
-        IBaseEntity::PostDuplicate(mode);
-    }
 
     virtual void
     SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;

--- a/ABasePawn/ABasePawn.h
+++ b/ABasePawn/ABasePawn.h
@@ -23,11 +23,12 @@ public:
         Super::BeginPlay();
         IBaseEntity::BeginPlay();
         ReportReady();
-
+        /*
         if (g_pGameBase && g_pGameBase->GameReady()) {
             PreInit();
             PostInit();
         }
+        */
     }
     void EndPlay(const EEndPlayReason::Type EndPlayReason) override {
         Super::EndPlay(EndPlayReason);

--- a/AGameBase/AGameBase.cpp
+++ b/AGameBase/AGameBase.cpp
@@ -17,34 +17,16 @@ void AGameBase::Tick(float deltaTime) {
         InitializeBaseEntities();
     }
 
-    // check for round restart
-    // also check for initialization of all entities (efficient place to do it)
-    if (g_pGlobals->curtime > m_tNextRoundRestart) {
-        // executing round restart statement
-        if (!m_bHasInitializedAllEntities && AllEntitiesReady()) {
-            // initializing all entities
-            InitializeAllEntities();
-        } else if (!AllEntitiesReady()) {
-            //?! This should never happen!
-            ADebug::Assert((bool)(s_iReadyEntityCount == s_iEntityCount),
-                           "s_iReadyEntityCount == s_iEntityCount");
-        } else {
-            // restarting round
-            RestartRound();
-        }
-        m_tNextRoundRestart = FLT_MAX;
-    }
+    int numBaseEntities = IBaseEntity::s_aBaseEntities.Num();
 
-    // execute all default thinks
-    for (eindex i = 0; i < g_entList.Num(); i++) {
-        // executing DefaultThink for BaseEntity g_entList[i]
-        g_entList[i]->DefaultThink();
+    for (eindex i = 0; i < numBaseEntities; i++) {
+        IBaseEntity::s_aBaseEntities[i]->DefaultThink();
     }
 
     // execute all the pointer-based thinks
-    for (eindex i = 0; i < g_entList.Num(); i++) {
-        if (g_entList[i]->GetNextThink() > g_pGlobals->curtime) {
-            g_entList[i]->Think();
+    for (eindex i = 0; i < numBaseEntities; i++) {
+        if (IBaseEntity::s_aBaseEntities[i]->GetNextThink() > g_pGlobals->curtime) {
+            IBaseEntity::s_aBaseEntities[i]->Think();
         }
     }
 
@@ -55,11 +37,6 @@ void AGameBase::Tick(float deltaTime) {
 void AGameBase::BeginPlay() {
     Super::BeginPlay();
 
-    /*
-    for (eindex i = 0; i < IBaseEntity::s_aBaseEntities.Num(); i++)
-    IBaseEntity::s_aBaseEntities[i]->PreInit();
-    */
-
     ADebug::Assert(s_iEntityCount == g_entList.Num(),
                    "\nIBaseEntity::s_iEntityCount == g_entList.Num()");
 
@@ -67,13 +44,6 @@ void AGameBase::BeginPlay() {
     m_bHasInitializedAllEntities = false;
 
     m_tNextRoundRestart = -FLT_MAX;
-}
-
-void AGameBase::EndPlay(const EEndPlayReason::Type EndPlayReason) {
-    Super::EndPlay(EndPlayReason);
-    IBaseEntity::s_bHasAlreadyInitializedBaseEntities = false;
-    m_bHasInitializedAllEntities                      = false;
-    g_pGlobals->markReset();
 }
 
 void AGameBase::RestartRound() {
@@ -120,7 +90,6 @@ void AGameBase::InitializeAllEntities() {
 }
 
 void AGameBase::InitializeBaseEntities() {
-    IBaseEntity::s_bHasAlreadyInitializedBaseEntities = true;
     eindex iNumEntities = IBaseEntity::s_aBaseEntities.Num();
 
     for (eindex i = 0; i < iNumEntities; i++)
@@ -128,4 +97,6 @@ void AGameBase::InitializeBaseEntities() {
 
     for (eindex i = 0; i < iNumEntities; i++)
         IBaseEntity::s_aBaseEntities[i]->PostInit();
+
+    IBaseEntity::s_bHasAlreadyInitializedBaseEntities = true;
 }

--- a/AGameBase/AGameBase.cpp
+++ b/AGameBase/AGameBase.cpp
@@ -23,70 +23,18 @@ void AGameBase::Tick(float deltaTime) {
         IBaseEntity::s_aBaseEntities[i]->DefaultThink();
     }
 
+    // TODO deprecate
+    /*
     // execute all the pointer-based thinks
     for (eindex i = 0; i < numBaseEntities; i++) {
         if (IBaseEntity::s_aBaseEntities[i]->GetNextThink() > g_pGlobals->curtime) {
             IBaseEntity::s_aBaseEntities[i]->Think();
         }
     }
+    */
 
     // update globals
-    g_pGlobals->update();
-}
-
-void AGameBase::BeginPlay() {
-    Super::BeginPlay();
-
-    ADebug::Assert(s_iEntityCount == g_entList.Num(),
-                   "\nIBaseEntity::s_iEntityCount == g_entList.Num()");
-
-    m_bHasRestartedRound         = false;
-    m_bHasInitializedAllEntities = false;
-
-    m_tNextRoundRestart = -FLT_MAX;
-}
-
-void AGameBase::RestartRound() {
-    // we need to do this right, otherwise when we iterate through
-    // the entity list, the size of the list might change
-    TArray<EHANDLE> m_aDestroyedEntities;
-    // this array remembers which entities we'll destroy later
-
-    for (int i = 0; i < g_entList.Num(); i++) {
-        IBaseEntity* pEnt = g_entList[i];
-
-        // ignore entities marked with preserve
-        if (!pEnt->HasFlags(FL_ROUND_PRESERVE)) {
-
-            // remember entities which need destruction
-            if (pEnt->HasFlags(FL_ROUND_DESTROY)) {
-                m_aDestroyedEntities.Add(pEnt->GetEHandle());
-                continue;
-            }
-        }
-    }
-
-    // now destroy everything marked in the list
-    while (m_aDestroyedEntities.Num() > 0) {
-        EHANDLE ent = m_aDestroyedEntities[0];
-        ent->DestroyEntity();
-        m_aDestroyedEntities.RemoveAt(0);
-    }
-}
-
-void AGameBase::InitializeAllEntities() {
-    // run pre inits of all entities
-    for (eindex i = 0; i < g_entList.Num(); i++) {
-        g_entList[i]->SetNextThink(FLT_MAX);
-        // g_entList[i]->PreInit();
-    }
-
-    // run post inits of all entities
-    // for (eindex i = 0; i < g_entList.Num(); i++)
-    //    g_entList[i]->PostInit();
-
-    // mark as ready
-    m_bHasInitializedAllEntities = true;
+    // g_pGlobals->update();
 }
 
 void AGameBase::InitializeBaseEntities() {

--- a/AGameBase/AGameBase.h
+++ b/AGameBase/AGameBase.h
@@ -17,10 +17,6 @@ public:
     GENERATED_BODY()
     AGameBase();
 
-    // UE4 Overrides create a new game flow. This does not use
-    // IBaseEntity::DefaultThink() nor IBaseEntity::Think() because if it
-    // did, the game flow would end up calling itself.
-    // virtual void BeginPlay() override;
     virtual void Tick(float deltaTime) override;
 
 private:

--- a/AGameBase/AGameBase.h
+++ b/AGameBase/AGameBase.h
@@ -22,7 +22,6 @@ public:
     // did, the game flow would end up calling itself.
     virtual void BeginPlay() override;
     virtual void Tick(float deltaTime) override;
-    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
     //-------------------------------------------------------------------------------------
     // Master game interface
@@ -36,11 +35,13 @@ public:
     bool GameReady() const { return m_bHasInitializedAllEntities; }
 
 private:
+    // TODO deprecate
     // daniel
     void InitializeAllEntities();
     // the cooler daniel
     void InitializeBaseEntities();
 
+    // TODO deprecate
     bool  m_bHasInitializedAllEntities;
     bool  m_bHasRestartedRound;
     ftime m_tNextRoundRestart;

--- a/AGameBase/AGameBase.h
+++ b/AGameBase/AGameBase.h
@@ -36,7 +36,10 @@ public:
     bool GameReady() const { return m_bHasInitializedAllEntities; }
 
 private:
+    // daniel
     void InitializeAllEntities();
+    // the cooler daniel
+    void InitializeBaseEntities();
 
     bool  m_bHasInitializedAllEntities;
     bool  m_bHasRestartedRound;

--- a/AGameBase/AGameBase.h
+++ b/AGameBase/AGameBase.h
@@ -20,31 +20,11 @@ public:
     // UE4 Overrides create a new game flow. This does not use
     // IBaseEntity::DefaultThink() nor IBaseEntity::Think() because if it
     // did, the game flow would end up calling itself.
-    virtual void BeginPlay() override;
+    // virtual void BeginPlay() override;
     virtual void Tick(float deltaTime) override;
 
-    //-------------------------------------------------------------------------------------
-    // Master game interface
-    //-------------------------------------------------------------------------------------
-
-public:
-    virtual void RestartRound();
-    inline void  SetNextRoundRestart(ftime next) { m_tNextRoundRestart = next; }
-    inline ftime GetNextResetRound() const { return m_tNextRoundRestart; }
-
-    bool GameReady() const { return m_bHasInitializedAllEntities; }
-
 private:
-    // TODO deprecate
-    // daniel
-    void InitializeAllEntities();
-    // the cooler daniel
     void InitializeBaseEntities();
-
-    // TODO deprecate
-    bool  m_bHasInitializedAllEntities;
-    bool  m_bHasRestartedRound;
-    ftime m_tNextRoundRestart;
 };
 
 extern AGameBase* g_pGameBase;

--- a/IBaseEntity/IBaseEntity.cpp
+++ b/IBaseEntity/IBaseEntity.cpp
@@ -7,7 +7,7 @@ TArray<IBaseEntity*> g_entList;
 // static variables are required to be redeclared in source file (cpp) for the linker
 // to detect it
 TArray<IBaseEntity*> IBaseEntity::s_aBaseEntities;
-bool IBaseEntity::s_bHasAlreadyInitializedBaseEntities;
+bool                 IBaseEntity::s_bHasAlreadyInitializedBaseEntities;
 
 // a global index which keeps track of where we last inserted an entity into the
 // list
@@ -29,9 +29,7 @@ IBaseEntity::IBaseEntity() {
     m_tLastTimeUsed = -FLT_MAX;
 }
 
-bool IBaseEntity::DestroyEntity() {
-    return GetActor()->Destroy();
-}
+bool IBaseEntity::DestroyEntity() { return GetActor()->Destroy(); }
 
 void IBaseEntity::PostInit() { RegisterInputsToControllers(); }
 

--- a/IBaseEntity/IBaseEntity.cpp
+++ b/IBaseEntity/IBaseEntity.cpp
@@ -27,64 +27,10 @@ IBaseEntity::IBaseEntity() {
     m_tConstructionTime = g_pGlobals->curtime;
 
     m_tLastTimeUsed = -FLT_MAX;
-
-    // in a cooked game PostDuplicate is not called so let's call it here
-    // we'll also call it if all other other BeginPlays have been called
-    if (IsCookedBuild() || g_pGlobals->worldcreated) AddEntityToLists(this);
 }
 
 bool IBaseEntity::DestroyEntity() {
-    RemoveSelfFromLists();
     return GetActor()->Destroy();
-}
-
-void IBaseEntity::RemoveSelfFromLists() {
-    g_ppEntityList[EntIndex()] = NULL;
-    g_entList.Remove(this);
-}
-
-void IBaseEntity::PostDuplicate(EDuplicateMode::Type mode) {
-    if (mode != EDuplicateMode::Normal) {
-        AddEntityToLists(this);
-        g_pGlobals->ineditor = false;
-    }
-}
-
-void IBaseEntity::AddEntityToLists(IBaseEntity* pEnt) {
-    g_entList.Add(pEnt);
-    s_iEntityCount++;
-
-    // now add it to the const-index array
-    eindex slot = -1;
-
-    // finds an empty slot if one exists
-    int checkCount = 0;
-    for (; ++g_iEntityCounter < MAX_ENTITY_COUNT && g_ppEntityList[g_iEntityCounter];
-         checkCount++)
-        ;
-
-    if (g_iEntityCounter != MAX_ENTITY_COUNT) {
-        slot = g_iEntityCounter;
-    } else {
-        g_iEntityCounter = 0;
-        checkCount       = MAX_ENTITY_COUNT - checkCount;
-
-        for (; ++g_iEntityCounter < checkCount && g_ppEntityList[g_iEntityCounter];)
-            ;
-
-        if (g_iEntityCounter != checkCount) { slot = g_iEntityCounter; }
-    }
-
-    // if a valid slot was not found
-    if (slot == -1) {
-        UE_LOG(LogTemp, Error,
-               TEXT("Could not find slot for new entity!\nThis most likely means "
-                    "that there are too many entities!"));
-    } else {
-        // assign entities
-        g_ppEntityList[slot] = pEnt;
-        pEnt->m_iEntIndex    = slot;
-    }
 }
 
 void IBaseEntity::PostInit() { RegisterInputsToControllers(); }

--- a/IBaseEntity/IBaseEntity.cpp
+++ b/IBaseEntity/IBaseEntity.cpp
@@ -4,8 +4,10 @@
 IBaseEntity*         g_ppEntityList[MAX_ENTITY_COUNT] = {NULL};
 TArray<IBaseEntity*> g_entList;
 
-// required to be redeclared in source file (cpp) for linker to detect it
+// static variables are required to be redeclared in source file (cpp) for the linker
+// to detect it
 TArray<IBaseEntity*> IBaseEntity::s_aBaseEntities;
+bool IBaseEntity::s_bHasAlreadyInitializedBaseEntities;
 
 // a global index which keeps track of where we last inserted an entity into the
 // list
@@ -85,9 +87,7 @@ void IBaseEntity::AddEntityToLists(IBaseEntity* pEnt) {
     }
 }
 
-void IBaseEntity::PostInit() {
-    RegisterInputsToControllers();
-}
+void IBaseEntity::PostInit() { RegisterInputsToControllers(); }
 
 IBaseEntity* IBaseEntity::FromActor(AActor* pActor) {
     // Epic disabled RTTI so we use this janky and hacky method instead

--- a/IBaseEntity/IBaseEntity.h
+++ b/IBaseEntity/IBaseEntity.h
@@ -81,11 +81,21 @@ public:
     // at any given moment
     static TArray<IBaseEntity*> s_aBaseEntities;
 
+    // bool whether entities have already been initialized (e.g. PreInits and
+    // PostInits called)
+    static bool s_bHasAlreadyInitializedBaseEntities;
+
 private:
     eindex m_iEntIndex;
 
 protected:
-    void BeginPlay() { IBaseEntity::s_aBaseEntities.Add(this); }
+    void BeginPlay() {
+        IBaseEntity::s_aBaseEntities.Add(this);
+        if (IBaseEntity::s_bHasAlreadyInitializedBaseEntities) {
+            PreInit();
+            PostInit();
+        }
+    }
     void EndPlay(const EEndPlayReason::Type EndPlayReason) {
         IBaseEntity::s_aBaseEntities.Remove(this);
     }
@@ -100,8 +110,8 @@ protected:
     //-------------------------------------------------------------------------------------
 
 public:
-    virtual void PreInit() {} // called before all the static intializers
-    virtual void PostInit();  // called after all the static initializers
+    virtual void PreInit() {}
+    virtual void PostInit();
 
     //-------------------------------------------------------------------------------------
     // Linkage to vanilla Unreal system

--- a/IBaseEntity/IBaseEntity.h
+++ b/IBaseEntity/IBaseEntity.h
@@ -62,7 +62,7 @@ interface IBaseEntity {
 public:
     friend class CGlobalVars; // allow CGlobalVars to access s_iEntityCount
     IBaseEntity();
-    virtual ~IBaseEntity() { RemoveSelfFromLists(); }
+    virtual ~IBaseEntity() {}
 
     ftime m_tConstructionTime;
     void  RemoveSelfFromLists(); // invalidates EHANDLES but DOES NOT modify static
@@ -79,6 +79,8 @@ public:
 
     // A collection of references to all BaseEntities present in the world
     // at any given moment
+    // NOTE: This information cannot be retrieved from a Blueprint since
+    // Blueprints cannot read IBaseEntities
     static TArray<IBaseEntity*> s_aBaseEntities;
 
     // bool whether entities have already been initialized (e.g. PreInits and
@@ -98,10 +100,10 @@ protected:
     }
     void EndPlay(const EEndPlayReason::Type EndPlayReason) {
         IBaseEntity::s_aBaseEntities.Remove(this);
+        PreDestroy();
+        PostDestroy();
     }
 
-    void        PostDuplicate(EDuplicateMode::Type mode);
-    static void AddEntityToLists(IBaseEntity * pEnt);
     static int  s_iReadyEntityCount;
     static int  s_iEntityCount;
 
@@ -112,6 +114,9 @@ protected:
 public:
     virtual void PreInit() {}
     virtual void PostInit();
+
+    virtual void PreDestroy() {}
+    virtual void PostDestroy() {};
 
     //-------------------------------------------------------------------------------------
     // Linkage to vanilla Unreal system
@@ -164,6 +169,7 @@ public:
     ent->ThinkSet((BASEPTR)(func), reinterpret_cast<void*>(ent))
 #define SetThink(func) SetThinkEnt(func, this)
 
+    // TODO deprecate
     static inline bool AllEntitiesReady() {
         return s_iReadyEntityCount == s_iEntityCount;
     }

--- a/IBaseEntity/IBaseEntity.h
+++ b/IBaseEntity/IBaseEntity.h
@@ -104,8 +104,8 @@ protected:
         PostDestroy();
     }
 
-    static int  s_iReadyEntityCount;
-    static int  s_iEntityCount;
+    static int s_iReadyEntityCount;
+    static int s_iEntityCount;
 
     //-------------------------------------------------------------------------------------
     // Initialization system
@@ -116,7 +116,7 @@ public:
     virtual void PostInit();
 
     virtual void PreDestroy() {}
-    virtual void PostDestroy() {};
+    virtual void PostDestroy(){};
 
     //-------------------------------------------------------------------------------------
     // Linkage to vanilla Unreal system

--- a/System/Globals.cpp
+++ b/System/Globals.cpp
@@ -42,7 +42,6 @@ void CGlobalVars::reset() {
     // remove defaults from list
     while (removedList.Num() > 0) {
         IBaseEntity* ent = removedList.Pop();
-        ent->RemoveSelfFromLists();
     }
 
     worldcreated = true;

--- a/System/Globals.h
+++ b/System/Globals.h
@@ -6,6 +6,7 @@
 
 using namespace std::chrono;
 
+// TODO deprecate
 class CGlobalVars {
 public:
     ftime curtime;


### PR DESCRIPTION
VRBase has grown into a large behemoth of code with highly extensible members; however, for the scopes of most projects, many of these features are largely unneeded and unused. We need a simpler VRBase set of classes which are easy for new VRBase contributers to understand and provide core functionality that is universal across the majority of VR projects.

In order to make VRBase a plugin, we need to remove all global variables or macros, since they will not translate over to individual project classes due to scope.

In particular, we will not be able to use `Globals` in the future and we need to phase out the code systematically. I believe the best way to go about this is by moving everything to `GameRules` (now renamed to `GameBase` as static members. In addition to controlling game logic flow, `GameBase` will also contain all generic project utilities and "global" variables that may be needed throughout a project.

This PR is one of many that will focus on cleaning existing `GameRules` code and moving global items into `GameRules`.

### Changes

In this PR, I have done the following:
- Added `PreDestroy` and `PostDestroy` methods following actor destruction for any callbacks or events that need to run when a `BaseEntity` is destroyed
- Refactor `PreInit` and `PostInit` to be called in `ABaseEntity`'s `BeginPlay` instead of in `PostDuplicate` and `BeginPlay`
- Remove the `BaseEntity` counter and instead create a `TArray` of `IBaseEntities`. This allows code extensions of a `BaseEntity` to get references to the actual actor and their properties instead of just the number of entities
- Deprecate the `Think` function. We don't really need multiple thinks and it complicates code by a lot